### PR TITLE
Updated Nuget.org link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * `Mock<T>.RaiseAsync` method for raising "async" events, i.e. events that use a `Func<..., Task>` or `Func<..., ValueTask>` delegate. (@stakx, #1313)
 * `setup.Verifiable(Times times, [string failMessage])` method to specify the expected number of calls upfront. `mock.Verify[All]` can then be used to check whether the setup was called that many times. The upper bound (maximum allowed number of calls) will be checked right away, i.e. whenever a setup gets called. (@stakx, #1319)
 * Add `ThrowsAsync` methods for non-generic `ValueTask` (@johnthcall, #1235)
+* Updated Nuget.org link to OpenMoq instad of Moq (@dannylloyd, #2)
 
 #### Fixed
 

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ You can read more about the "why" and see some nice screenshots at [kzu's blog](
 
 ## Where?
 
-See our [Quickstart](https://github.com/ImoutoChan/openmoq/wiki/Quickstart) examples to get a feeling of the extremely simple API and install from [NuGet](http://nuget.org/packages/moq).
+See our [Quickstart](https://github.com/ImoutoChan/openmoq/wiki/Quickstart) examples to get a feeling of the extremely simple API and install from [NuGet](http://nuget.org/packages/openmoq).
 
 Read about the announcement at [kzu's blog](https://web.archive.org/web/20201130233544/http://blogs.clariusconsulting.net/kzu/linq-to-mock-moq-is-born/). Get some background on [the state of mock libraries from Scott Hanselman](http://www.hanselman.com/blog/MoqLinqLambdasAndPredicatesAppliedToMockObjects.aspx).
 


### PR DESCRIPTION
Updated Nuget.org link to point to OpenMoq instead of Moq